### PR TITLE
keccak: Actually pipeline keccak_pipelined

### DIFF
--- a/src/math/keccak/keccak_p.sv
+++ b/src/math/keccak/keccak_p.sv
@@ -1,30 +1,30 @@
 `timescale 1 ns / 1 ps
 
 module keccak_p #(
-    parameter l = 6,
-    parameter n = 4,
-    parameter w = 2**l,
-    parameter b = 25*w
+    parameter L = 6,
+    parameter N = 4,
+    parameter W = 2**L,
+    parameter B = 25*W
 ) (
     input  logic clk,
     input  logic enable,
     input  logic reset,
-    input  logic [b-1:0] x,
-    input  logic [n-1:0][l:0] rc,
-    output logic [b-1:0] y
+    input  logic [B-1:0] x,
+    input  logic [N-1:0][L:0] rc,
+    output logic [B-1:0] y
 );
 
     // keccak_p encapsulates n sequentially-connected keccak_rounds, with the result fed into a
     // b-bit register. This allows us to subdivide the keccak function into a multicycle process.
     // See FIPS202 section 3.3 for details.
 
-    logic [b-1:0] m [n+1] /*verilator split_var*/; // Intermediates to connect rounds
+    logic [B-1:0] m [N+1] /*verilator split_var*/; // Intermediates to connect rounds
     assign m[0] = x;
 
-    // Construct n rounds connected sequentially
+    // Construct N rounds connected sequentially
     generate
-        for (genvar round = 0; round < n; round++) begin: round_select
-            keccak_round #(l) keccak_rnd (
+        for (genvar round = 0; round < N; round++) begin: round_select
+            keccak_round #(L) keccak_rnd (
                 .x(m[round]),
                 .rc(rc[round]),
                 .y(m[round+1])
@@ -33,9 +33,9 @@ module keccak_p #(
     endgenerate
 
     // Register the output of the final round
-    dffre #(.width(b)) state_reg (
+    dffre #(.width(B)) state_reg (
         .clk, .reset, .enable,
-        .d(m[n]),
+        .d(m[N]),
         .q(y)
     );
 

--- a/src/math/keccak/keccak_round.sv
+++ b/src/math/keccak/keccak_round.sv
@@ -2,8 +2,8 @@
 
 module keccak_round #(
     parameter L = 6,
-    parameter W = 2**l,
-    parameter B = 25*w
+    parameter W = 2**L,
+    parameter B = 25*W
 ) (
     input  logic [B-1:0] x,
     input  logic   [L:0] rc,
@@ -17,7 +17,7 @@ module keccak_round #(
     logic [4:0][4:0][W-1:0] x_block, x_pi, x_chi, y_block;
 
     // Reorganize i/o into 3-dimensional blocks for easy indexing in subfunctions
-    vector2block #(.W, .B v2b (.vector(x), .block(x_block));
+    vector2block #(.W, .B) v2b (.vector(x), .block(x_block));
     block2vector #(.W, .B) b2v (.block(y_block), .vector(y));
 
     // Perform a single round of the keccak-p permutation

--- a/src/math/keccak/keccak_round.sv
+++ b/src/math/keccak/keccak_round.sv
@@ -1,34 +1,28 @@
 `timescale 1 ns / 1 ps
 
 module keccak_round #(
-    parameter l = 6,
-    parameter w = 2**l,
-    parameter b = 25*w
+    parameter L = 6,
+    parameter W = 2**l,
+    parameter B = 25*w
 ) (
-    input  logic [b-1:0] x,
-    input  logic   [l:0] rc,
-    output logic [b-1:0] y
+    input  logic [B-1:0] x,
+    input  logic   [L:0] rc,
+    output logic [B-1:0] y
 );
 
     // keccak_round encapsulates a single step of the keccak transformation function.
     // Each step contains theta, rho, pi, chi, and iota subfunctions in sequence.
     // See FIPS202 section 3.2 for details.
 
-    logic [4:0][4:0][w-1:0] x_block, x_pi, x_chi, y_block;
+    logic [4:0][4:0][W-1:0] x_block, x_pi, x_chi, y_block;
 
     // Reorganize i/o into 3-dimensional blocks for easy indexing in subfunctions
-    generate
-        for (genvar i = 0; i < 5; i++) begin: sheet_select
-            for (genvar j = 0; j < 5; j++) begin: lane_select
-                assign x_block[i][j] = x[w*(i+5*j)+:w];
-                assign y[w*(i+5*j)+:w] = y_block[i][j];
-            end
-        end
-    endgenerate
+    vector2block #(.W, .B v2b (.vector(x), .block(x_block));
+    block2vector #(.W, .B) b2v (.block(y_block), .vector(y));
 
     // Perform a single round of the keccak-p permutation
-    keccak_theta_rho_pi #(w) thrhp (.x(x_block), .y(x_pi));
-    keccak_chi          #(w) chi   (.x(x_pi),    .y(x_chi));
-    keccak_iota         #(l) iota  (.x(x_chi),   .y(y_block), .rc);
+    keccak_theta_rho_pi #(.W) thrhp (.x(x_block), .y(x_pi));
+    keccak_chi          #(.W) chi   (.x(x_pi),    .y(x_chi));
+    keccak_iota         #(.L) iota  (.x(x_chi),   .y(y_block), .rc);
 
 endmodule

--- a/src/math/keccak/keccak_staged.sv
+++ b/src/math/keccak/keccak_staged.sv
@@ -1,12 +1,18 @@
 `timescale 1 ns / 1 ps
 
-module keccak_pipelined #(
+// keccak_staged implements a Q-cycle staged keccak sponge function.
+// This module completes the keccak sponge operation in Q cycles, where Q may be any of the
+// following: 48 (2-cycle split round), 24 (1 round/cycle), 12 (2 rounds/cycle), 8, 6, 4, 3, 2, 1.
+// TODO: Implement staging based on Q parameter
+
+module keccak_staged #(
     parameter D = 512,      // digest length in bits
     parameter L = 6,        // log base 2 of lane size. L=6 for all SHA3/SHAKE ops.
     parameter W = 2**L,     // lane size (i.e. word length) in bits
     parameter B = 25*W,     // keccak permuation width in bits
     parameter C = 2*D,      // capacity of the sponge function in bits
-    parameter R = B - C     // rate of the sponge function in bits
+    parameter R = B - C,    // rate of the sponge function in bits
+    parameter Q = 48        // reserved for future use. number of cycles to complete a sponge operation
 ) (
     input  logic         clk, reset, enable,
     input  logic         op,

--- a/src/math/keccak/keccak_staged.sv
+++ b/src/math/keccak/keccak_staged.sv
@@ -9,14 +9,11 @@ module keccak_pipelined #(
     parameter R = B - C     // rate of the sponge function in bits
 ) (
     input  logic         clk, reset, enable,
+    input  logic         op,
     input  logic   [4:0] round,
     input  logic [R-1:0] message,
     output logic [D-1:0] digest
 );
-    // TODO: investigate variable capacity/rate (i.e. to allow <512 bit digests on SHA3-512 hardware)
-    //  - Assume the parameters D, C, and R are max widths
-    //  - adding an "input logic [...] capacity " should allow us to dynamically switch both capacity and rate
-
     logic [23:0][6:0] iota_consts = {
         7'b0010111,
         7'b1000010,
@@ -44,27 +41,22 @@ module keccak_pipelined #(
         7'b1000000
     };
     logic [B-1:0] x, y, q;
-    logic [4:0][4:0][W-1:0] x_block, y_pi, y_chi, y_iota, q_block;
+    logic [4:0][4:0][W-1:0] x_block, y_pi, y_chi, y_iota, y_block;
 
     assign x = {q[B-1:C] ^ message, q[C-1:0]};
-    vector2block #(W) v2b (.vector((round == 0) ? x : q), .block(x_block));
+    vector2block #(W) v2b (.vector((round == 0) && (op == 0) ? x : q), .block(x_block));
 
-    // stage 1: fused & optimized theta/rho/pi
+    // op 0: fused & optimized theta/rho/pi
     keccak_theta_rho_pi #(W) theta_rho_pi (.x(x_block), .y(y_pi));
-    generate
-        for (genvar i = 0; i < 5; i++) begin: sheet_select
-            for (genvar j = 0; j < 5; j++) begin: lane_select
-                dffre #(.width(W)) lane_reg (.clk, .reset, .enable, .d(y_pi[i][j]), .q(q_block[i][j]));
-            end
-        end
-    endgenerate
 
-    // stage 2: fused chi/iota
-    keccak_chi  #(W) chi  (.x(q_block), .y(y_chi));
-    keccak_iota #(L) iota (.x(y_chi), .y(y_iota), .rc(iota_consts[round]));
-    block2vector #(W) b2v (.block(y_iota), .vector(y));
+    // op 1: fused chi/iota
+    keccak_chi          #(W) chi          (.x(x_block), .y(y_chi));
+    keccak_iota         #(L) iota         (.x(y_chi), .y(y_iota), .rc(iota_consts[round]));
+
+    assign y_block = op ? y_iota : y_pi;
+
+    block2vector #(W) b2v (.block(y_block), .vector(y));
     dffre #(.width(B)) iota_reg (.clk, .reset, .enable, .d(y), .q);
-
     assign digest = q[B-1-:D];
 
 endmodule

--- a/src/math/keccak/permutations/keccak_chi.sv
+++ b/src/math/keccak/permutations/keccak_chi.sv
@@ -1,10 +1,10 @@
 `timescale 1 ns / 1 ps
 
 module keccak_chi #(
-    parameter w = 64
+    parameter W = 64
 ) (
-    input  logic [4:0][4:0][w-1:0] x,
-    output logic [4:0][4:0][w-1:0] y
+    input  logic [4:0][4:0][W-1:0] x,
+    output logic [4:0][4:0][W-1:0] y
 );
 
     generate

--- a/src/math/keccak/permutations/keccak_iota.sv
+++ b/src/math/keccak/permutations/keccak_iota.sv
@@ -1,5 +1,8 @@
 `timescale 1 ns / 1 ps
 
+// Optimized keccak iota stage. Uses minimized 7-bit round constants as in
+// https://link.springer.com/article/10.1007/s13389-023-00334-0.
+
 module keccak_iota #(
     parameter l = 6,
     parameter w = 2**l

--- a/src/math/keccak/permutations/keccak_iota.sv
+++ b/src/math/keccak/permutations/keccak_iota.sv
@@ -4,19 +4,19 @@
 // https://link.springer.com/article/10.1007/s13389-023-00334-0.
 
 module keccak_iota #(
-    parameter l = 6,
-    parameter w = 2**l
+    parameter L = 6,
+    parameter W = 2**L
 ) (
-    input  logic [4:0][4:0][w-1:0] x,
-    input  logic             [l:0] rc,
-    output logic [4:0][4:0][w-1:0] y
+    input  logic [4:0][4:0][W-1:0] x,
+    input  logic             [L:0] rc,
+    output logic [4:0][4:0][W-1:0] y
 );
 
     generate
         for (genvar i = 0; i < 5; i++) begin: sheet_select
             for (genvar j = 0; j < 5; j++) begin: lane_select
                 if ((i == 4) & (j == 4)) begin: apply_rc
-                    for (genvar k = 0; k < w; k++) begin: bit_select
+                    for (genvar k = 0; k < W; k++) begin: bit_select
                         // Note: The indices are a bit strange here because we're compensating for
                         // byte-endianness. If you reverse the order of the bytes, the indices
                         // match up with Sideris et. al.

--- a/src/math/keccak/permutations/keccak_pi.sv
+++ b/src/math/keccak/permutations/keccak_pi.sv
@@ -1,10 +1,10 @@
 `timescale 1 ns / 1 ps
 
 module keccak_pi #(
-    parameter w = 64
+    parameter W = 64
 ) (
-    input  logic [4:0][4:0][w-1:0] x,
-    output logic [4:0][4:0][w-1:0] y
+    input  logic [4:0][4:0][W-1:0] x,
+    output logic [4:0][4:0][W-1:0] y
 );
 
     generate

--- a/src/math/keccak/permutations/keccak_rho.sv
+++ b/src/math/keccak/permutations/keccak_rho.sv
@@ -1,13 +1,13 @@
 `timescale 1 ns / 1 ps
 
 module keccak_rho #(
-    parameter w = 64
+    parameter W = 64
 ) (
-    input  logic [4:0][4:0][w-1:0] x,
-    output logic [4:0][4:0][w-1:0] y
+    input  logic [4:0][4:0][W-1:0] x,
+    output logic [4:0][4:0][W-1:0] y
 );
 
-    logic [23:0][w-1:0] A, B; // temp wires for flipping bytes
+    logic [23:0][W-1:0] A, B; // temp wires for flipping bytes
     localparam int rho_offsets [24:0] = { // These work for all SHA3/SHAKE variations
           0,   1, 190,  28,  91,
          36, 300,   6,  55, 276,
@@ -24,11 +24,11 @@ module keccak_rho #(
                 if (rho_offsets[5*j+i] == 0) begin: rotate_0
                     assign y[i][j] = x[i][j];
                 end else begin: rotate_n
-                    for (genvar k = 0; k < w/8; k++) begin: byte_flip_A
+                    for (genvar k = 0; k < W/8; k++) begin: byte_flip_A
                         assign A[5*j+i][8*k+:8] = {<<1{x[i][j][8*k+:8]}}; // reverse the bit order of each byte
                     end
-                    assign B[5*j+i] = {A[5*j+i][(rho_offsets[5*j+i]%w)-1:0], A[5*j+i][w-1:(rho_offsets[5*j+i]%w)]}; // rol
-                    for (genvar m = 0; m < w/8; m++) begin: byte_flip_B
+                    assign B[5*j+i] = {A[5*j+i][(rho_offsets[5*j+i]%W)-1:0], A[5*j+i][W-1:(rho_offsets[5*j+i]%W)]}; // rol
+                    for (genvar m = 0; m < W/8; m++) begin: byte_flip_B
                         assign y[i][j][8*m+:8] = {<<1{B[5*j+i][8*m+:8]}};
                     end
                 end

--- a/src/math/keccak/permutations/keccak_theta.sv
+++ b/src/math/keccak/permutations/keccak_theta.sv
@@ -1,21 +1,21 @@
 `timescale 1 ns / 1 ps
 
 module keccak_theta #(
-    parameter w = 64
+    parameter W = 64
 ) (
-    input  logic [4:0][4:0][w-1:0] x,
-    output logic [4:0][4:0][w-1:0] y
+    input  logic [4:0][4:0][W-1:0] x,
+    output logic [4:0][4:0][W-1:0] y
 );
 
-    logic [4:0][w-1:0] C;
-    logic [4:0][w-1:0] D;
+    logic [4:0][W-1:0] C;
+    logic [4:0][W-1:0] D;
 
     generate
         for (genvar i = 0; i < 5; i++) begin: sheet_select
             assign C[i] = x[i][0] ^ x[i][1] ^ x[i][2] ^ x[i][3] ^ x[i][4];
-            for (genvar k = 0; k < w/8; k++) begin: byte_select
+            for (genvar k = 0; k < W/8; k++) begin: byte_select
                 // We have to do this awful nonsense to compensate for the difference in endianness from c to sv
-                assign D[i][8*k+:8] = {C[(i+4)%5][8*k+:7], C[(i+4)%5][(8*(k+2)-1)%w]} ^ C[(i+1)%5][8*k+:8];
+                assign D[i][8*k+:8] = {C[(i+4)%5][8*k+:7], C[(i+4)%5][(8*(k+2)-1)%W]} ^ C[(i+1)%5][8*k+:8];
             end
             for (genvar j = 0; j < 5; j++) begin: lane_select
                 assign y[i][j] = x[i][j] ^ D[i];

--- a/src/math/keccak/permutations/keccak_theta_rho_pi.sv
+++ b/src/math/keccak/permutations/keccak_theta_rho_pi.sv
@@ -1,10 +1,10 @@
 `timescale 1 ns / 1 ps
 
 module keccak_theta_rho_pi #(
-    parameter w = 64
+    parameter W = 64
 ) (
-    input  logic [4:0][4:0][w-1:0] x,
-    output logic [4:0][4:0][w-1:0] y
+    input  logic [4:0][4:0][W-1:0] x,
+    output logic [4:0][4:0][W-1:0] y
 );
 
     localparam int rho_offsets [24:0] = { // These work for all SHA3/SHAKE variations
@@ -15,17 +15,17 @@ module keccak_theta_rho_pi #(
         210,  66, 253, 120,  78
     };
 
-    logic [23:0][w-1:0] A, B; // Temp wires for flipping bytes
-    logic  [4:0][w-1:0] C, D; // As defined in FIPS202 section 3.2.1
+    logic [23:0][W-1:0] A, B; // Temp wires for flipping bytes
+    logic  [4:0][W-1:0] C, D; // As defined in FIPS202 section 3.2.1
 
     generate
         for (genvar i = 0; i < 5; i++) begin: sheet_select
 
             // Theta prep: assign C, D
             assign C[i] = x[i][0] ^ x[i][1] ^ x[i][2] ^ x[i][3] ^ x[i][4];
-            for (genvar l = 0; l < w/8; l++) begin: theta_byte_select
+            for (genvar l = 0; l < W/8; l++) begin: theta_byte_select
                 // Perform word and sheet rotations while accounting for byte-endianness
-                assign D[i][8*l+:8] = {C[(i+4)%5][8*l+:7], C[(i+4)%5][(8*(l+2)-1)%w]} ^ C[(i+1)%5][8*l+:8];
+                assign D[i][8*l+:8] = {C[(i+4)%5][8*l+:7], C[(i+4)%5][(8*(l+2)-1)%W]} ^ C[(i+1)%5][8*l+:8];
             end
 
             // Theta / Rho / Pi: compute theta results while performing rho rotate and pi permute
@@ -35,13 +35,13 @@ module keccak_theta_rho_pi #(
                     assign y[j][(2*i+3*j+4)%5] = x[i][j] ^ D[i];
                 end else begin: rotate_by_rho_offset
                     // Theta: compute theta result then reverse byte endianness for rotation
-                    for (genvar m = 0; m < w/8; m++) begin: rho_byte_flip_A
+                    for (genvar m = 0; m < W/8; m++) begin: rho_byte_flip_A
                         assign A[i+5*j][8*m+:8] = {<<1{x[i][j][8*m+:8] ^ D[i][8*m+:8]}};
                     end
                     // Rho: rotate left by specified offset
-                    assign B[i+5*j] = {A[i+5*j][(rho_offsets[i+5*j]%w)-1:0], A[i+5*j][w-1:(rho_offsets[i+5*j]%w)]};
+                    assign B[i+5*j] = {A[i+5*j][(rho_offsets[i+5*j]%W)-1:0], A[i+5*j][W-1:(rho_offsets[i+5*j]%W)]};
                     // Pi: restore endianness and permute
-                    for (genvar n = 0; n < w/8; n++) begin: rho_byte_flip_B
+                    for (genvar n = 0; n < W/8; n++) begin: rho_byte_flip_B
                         assign y[j][(2*i+3*j+4)%5][8*n+:8] = {<<1{B[i+5*j][8*n+:8]}};
                     end
                 end

--- a/tb/tb_sha3_pipelined.sv
+++ b/tb/tb_sha3_pipelined.sv
@@ -18,7 +18,7 @@ module tb_sha3_pipelined #(
 
     keccak_pipelined #(D) dut (
         .clk, .reset, .enable,
-        .op, .round,
+        .round,
         .message, .digest
     );
     assign op = cycle_counter % 2;


### PR DESCRIPTION
- Add pipelining to keccak_pipelined
- Rename the previous 2-op keccak_pipelined to keccak_staged. In the future this file will replace keccak_multicycle as well, with a single parameterized file allowing sponge function operation in anywhere from 1 to 48 cycles.
- Improve documentation on keccak_iota
- Update tb_sha3_pipelined with changes to keccak_pipelined

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a staged Keccak cryptographic module exposing a clocked digest interface for sponge/permute operations.

* **Refactor**
  * Simplified and standardized module interfaces and parameter naming for consistency.
  * Restructured internal datapath and pipeline for more deterministic round handling and register staging.

* **Documentation**
  * Improved explanatory comments for permutation components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->